### PR TITLE
Moved `smart_pot` function call order

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -21,8 +21,8 @@ void cycle() {
   receivedResponse = false;
 
   uint8_t moisture = smart_pot_getMoisture();
-  uint8_t watered = smart_pot_tryWater(moisture);
   uint8_t waterLevel = smart_pot_getWaterLevel();
+  uint8_t watered = smart_pot_tryWater(moisture);
 
   // Send the data to the serial monitor
   char result[128];


### PR DESCRIPTION
- Moved `smart_pot_getWaterLevel` before `smart_pot_tryWater`, since a user could have filled the container after a cycle has measured the water level to be lower than 5 causing it not to water even though the container had enough water the next cycle.